### PR TITLE
Fix output capability feature name

### DIFF
--- a/blocks/sharpening/src/helpers.py
+++ b/blocks/sharpening/src/helpers.py
@@ -11,7 +11,8 @@ from rasterio.windows import Window
 import numpy as np
 
 
-AOICLIPPED = "up42.data.aoiclipped"
+IN_CAPABILITY = "up42.data.aoiclipped"
+OUT_CAPABILITY = "up42.data.aoiclipped"
 
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 

--- a/blocks/sharpening/src/helpers.py
+++ b/blocks/sharpening/src/helpers.py
@@ -1,9 +1,9 @@
 import os
 import json
-import pathlib
+from pathlib import Path
 import shutil
 import logging
-from typing import Any, Iterable, Union
+from typing import Any, Iterable, Union, Tuple
 
 from geojson import Feature, FeatureCollection
 import rasterio as rio
@@ -35,12 +35,12 @@ def set_capability(feature: Feature, capability: str, value: Any) -> Feature:
 
 
 def ensure_data_directories_exist():
-    pathlib.Path("/tmp/input/").mkdir(parents=True, exist_ok=True)
-    pathlib.Path("/tmp/output/").mkdir(parents=True, exist_ok=True)
-    pathlib.Path("/tmp/quicklooks/").mkdir(parents=True, exist_ok=True)
+    Path("/tmp/input/").mkdir(parents=True, exist_ok=True)
+    Path("/tmp/output/").mkdir(parents=True, exist_ok=True)
+    Path("/tmp/quicklooks/").mkdir(parents=True, exist_ok=True)
 
 
-def setup_test_directories(test_dir: pathlib.Path):
+def setup_test_directories(test_dir: Path):
     """
     Creates given test directory (usually /tmp or /tmp/e2e_test) and empty input/output/quicklook subfolders.
     """
@@ -49,11 +49,11 @@ def setup_test_directories(test_dir: pathlib.Path):
     for folder in ["input", "output", "quicklooks"]:
         try:
             shutil.rmtree(test_dir / folder)
-            pathlib.Path(test_dir / folder).mkdir(parents=True, exist_ok=True)
+            Path(test_dir / folder).mkdir(parents=True, exist_ok=True)
         # Deleting subfolder sometimes does not work in temp, then remove all subfiles.
         except (PermissionError, OSError):
-            pathlib.Path(test_dir / folder).mkdir(parents=True, exist_ok=True)
-            files_to_delete = pathlib.Path(test_dir / folder).rglob("*.*")
+            Path(test_dir / folder).mkdir(parents=True, exist_ok=True)
+            files_to_delete = Path(test_dir / folder).rglob("*.*")
             for file_path in files_to_delete:
                 file_path.unlink()
 

--- a/blocks/sharpening/src/helpers.py
+++ b/blocks/sharpening/src/helpers.py
@@ -58,6 +58,45 @@ def setup_test_directories(test_dir: Path):
                 file_path.unlink()
 
 
+def get_in_out_feature_names_and_paths(
+    in_feature: Feature, in_capability: str, postfix: str = ""
+) -> Tuple[str, str, Path, Path]:
+    """
+    Utility to generate the input and output feature names and file paths. Will create
+    parent directory(ies) of output file by default. Optionally augments the output filename
+    with a postfix.
+
+    Parameters
+    ----------
+    in_feature : A Feature of a GeoJSON FeatureCollection describing all input datasets
+    postfix : (Optional) Additional string to add to the end of the file name before
+        the file suffix. Adds "_" plus postfix.
+
+    Returns
+    -------
+        Tuple with str of in- & output feature names and in- & output file paths.
+    """
+    in_feature_name = in_feature["properties"][in_capability]
+    in_feature_path = Path("/tmp/input") / in_feature_name
+
+    if postfix == "":
+        out_feature_name = in_feature_name
+    else:
+        in_feature_name = Path(in_feature_name)
+        out_feature_name = in_feature_name.with_name(
+            in_feature_name.stem + "_" + postfix + in_feature_name.suffix
+        )
+    out_feature_path = Path("/tmp/output") / out_feature_name
+    out_feature_path.parent.mkdir(parents=True, exist_ok=True)
+
+    return (
+        str(in_feature_name),
+        str(out_feature_name),
+        in_feature_path,
+        out_feature_path,
+    )
+
+
 def load_params() -> dict:
     """
     Get the parameters for the current task directly from the task parameters.

--- a/blocks/sharpening/src/helpers.py
+++ b/blocks/sharpening/src/helpers.py
@@ -69,6 +69,7 @@ def get_in_out_feature_names_and_paths(
     Parameters
     ----------
     in_feature : A Feature of a GeoJSON FeatureCollection describing all input datasets
+    in_capability: Input capability key.
     postfix : (Optional) Additional string to add to the end of the file name before
         the file suffix. Adds "_" plus postfix.
 

--- a/blocks/sharpening/src/sharpening.py
+++ b/blocks/sharpening/src/sharpening.py
@@ -90,7 +90,8 @@ class RasterSharpener:
 
             with rio.open(str(output_file_path), "w", **out_profile) as dst:
 
-                # Windowed read and write, buffered window by 4 pixels to enable correct 5x5 kernel operation.
+                # Windowed read and write, buffered window by 4 pixels to enable correct
+                # 5x5 kernel operation.
                 windows_util = WindowsUtil(src)
 
                 for window, window_buffered in windows_util.windows_buffered(buffer=4):

--- a/blocks/sharpening/src/sharpening.py
+++ b/blocks/sharpening/src/sharpening.py
@@ -136,7 +136,7 @@ class RasterSharpener:
                 out_feature_dir.stem + "_sharpened.tif"
             )
             out_feature_dir.parent.mkdir(parents=True, exist_ok=True)
-            out_feature_name = str(Path(*out_feature_dir.parts[-2:]))
+            out_feature_name = in_feature_name.replace(".tif", "_sharpened.tif")
             logger.debug("Output file: %s", out_feature_name)
 
             self.sharpen_raster(in_feature_path, out_feature_dir)

--- a/blocks/sharpening/src/sharpening.py
+++ b/blocks/sharpening/src/sharpening.py
@@ -7,13 +7,15 @@ import rasterio as rio
 from skimage.filters import unsharp_mask
 
 from helpers import (
-    AOICLIPPED,
-    set_capability,
+    IN_CAPABILITY,
+    OUT_CAPABILITY,
     get_logger,
+    ensure_data_directories_exist,
+    get_in_out_feature_names_and_paths,
+    set_capability,
     save_metadata,
     load_params,
     load_metadata,
-    ensure_data_directories_exist,
     WindowsUtil,
 )
 
@@ -121,33 +123,26 @@ class RasterSharpener:
         """
         logger.debug("Sharpening started...")
 
+        ensure_data_directories_exist()
+
         results: List[Feature] = []
         for in_feature in metadata.features:
-            process_dir = Path("/tmp")
-            input_dir = process_dir / "input"
-            out_dir = process_dir / "output"
-            ensure_data_directories_exist()
-
-            in_feature_name = in_feature["properties"][AOICLIPPED]
-            in_feature_path = input_dir / in_feature_name
-            logger.debug("Input file: %s", str(in_feature_name))
-
-            out_feature_dir = Path(out_dir / in_feature_name)
-            out_feature_dir = out_feature_dir.with_name(
-                out_feature_dir.stem + "_sharpened.tif"
+            in_feature_name, out_feature_name, in_feature_path, out_feature_path = get_in_out_feature_names_and_paths(
+                in_feature, IN_CAPABILITY
             )
-            out_feature_dir.parent.mkdir(parents=True, exist_ok=True)
-            out_feature_name = in_feature_name.replace(".tif", "_sharpened.tif")
+
+            logger.debug("Input file: %s", in_feature_name)
             logger.debug("Output file: %s", out_feature_name)
 
-            self.sharpen_raster(in_feature_path, out_feature_dir)
+            self.sharpen_raster(in_feature_path, out_feature_path)
 
             out_feature = Feature(
                 geometry=in_feature["geometry"], bbox=in_feature["bbox"]
             )
             out_feature["properties"] = self.get_metadata(in_feature)
-            set_capability(out_feature, AOICLIPPED, out_feature_name)
+            set_capability(out_feature, OUT_CAPABILITY, out_feature_name)
             results.append(out_feature)
+
             logger.debug("File %s was sharpened.", out_feature_name)
 
         return FeatureCollection(results)

--- a/blocks/sharpening/tests/context.py
+++ b/blocks/sharpening/tests/context.py
@@ -9,10 +9,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../s
 # pylint: disable=unused-import,wrong-import-position
 from src.sharpening import RasterSharpener
 from src.helpers import (
-    AOICLIPPED,
-    LOG_FORMAT,
-    get_logger,
-    load_params,
+    IN_CAPABILITY,
+    OUT_CAPABILITY,
     ensure_data_directories_exist,
     setup_test_directories,
+    get_logger,
+    load_params,
 )

--- a/blocks/sharpening/tests/context.py
+++ b/blocks/sharpening/tests/context.py
@@ -9,8 +9,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../s
 # pylint: disable=unused-import,wrong-import-position
 from src.sharpening import RasterSharpener
 from src.helpers import (
-    IN_CAPABILITY,
-    OUT_CAPABILITY,
     ensure_data_directories_exist,
     setup_test_directories,
     get_logger,

--- a/blocks/sharpening/tests/test_sharpening.py
+++ b/blocks/sharpening/tests/test_sharpening.py
@@ -122,17 +122,15 @@ def test_process(tmp_raster_fixture):
     Checks the raster processing for multiple images.
     """
     in_path, _ = tmp_raster_fixture
-
     img_file_list = [in_path]
 
     feature_list: List[Feature] = []
-
     for img_path in img_file_list:
         bbox = [2.5, 1.0, 4.0, 5.0]
         geom = box(*bbox)
 
         in_properties = {
-            AOICLIPPED: str(Path(*img_path.parts[-2:])),
+            "up42.data.aoiclipped": str(Path(*img_path.parts[-2:])),
             "acquisitionDate": "2018-10-16T10:39:43.431Z",
         }
         feature_list.append(Feature(geometry=geom, bbox=bbox, properties=in_properties))
@@ -145,7 +143,7 @@ def test_process(tmp_raster_fixture):
 
     for feature in output_fc.features:
         # Check that file paths in metadata are relative
-        feature_file = feature["properties"][AOICLIPPED]
+        feature_file = feature["properties"]["up42.data.aoiclipped"]
         assert Path(feature_file).root == ""
         # Check that metadata is propagated
         assert feature["properties"]["acquisitionDate"] == "2018-10-16T10:39:43.431Z"

--- a/blocks/sharpening/tests/test_sharpening.py
+++ b/blocks/sharpening/tests/test_sharpening.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from context import RasterSharpener
 
-from context import AOICLIPPED, ensure_data_directories_exist, setup_test_directories
+from context import ensure_data_directories_exist, setup_test_directories
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/e2e.py
+++ b/e2e.py
@@ -46,8 +46,7 @@ if __name__ == "__main__":
 
     # Check number of files in output_prefix
     OUTPUT_SHARPEN = (
-        TEST_DIR
-        / "output"
+        OUTPUT_DIR
         / Path(FEATURE_COLLECTION.features[0].properties["up42.data.aoiclipped"])
     )
 

--- a/e2e.py
+++ b/e2e.py
@@ -45,9 +45,8 @@ if __name__ == "__main__":
     print(FEATURE_COLLECTION.features[0].bbox)
 
     # Check number of files in output_prefix
-    OUTPUT_SHARPEN = (
-        OUTPUT_DIR
-        / Path(FEATURE_COLLECTION.features[0].properties["up42.data.aoiclipped"])
+    OUTPUT_SHARPEN = OUTPUT_DIR / Path(
+        FEATURE_COLLECTION.features[0].properties["up42.data.aoiclipped"]
     )
 
     print(OUTPUT_SHARPEN)


### PR DESCRIPTION
- Fixes the output capability feature name to be correct regardless of "filename" or "foldername/filename" structure.
- Simlified input and output feature name and file path handling.
- Makes the capability concept easier understandable by introducing more descriptive and separate input and output capability variables.

* [x] Unit & e2e test successful
* [x] Tested as custom block with more more than one dataset
* [x] Tested as custom block with another block consuming its output
* [ ] Bump block version (?)